### PR TITLE
Hook Updates

### DIFF
--- a/show_damage/scripts/mods/show_damage/show_damage.lua
+++ b/show_damage/scripts/mods/show_damage/show_damage.lua
@@ -1131,8 +1131,8 @@ end
 --]]
 for breed_name, template in pairs(DeathReactions.templates) do
 	if template.unit and template.husk and template.unit.start and template.husk.start then
-		mod:hook("DeathReactions.templates."..breed_name..".unit.start", DeathReactions_start_hook)
-		mod:hook("DeathReactions.templates."..breed_name..".husk.start", DeathReactions_start_hook)
+		mod:hook(template.unit, "start", DeathReactions_start_hook)
+		mod:hook(template.husk, "start", DeathReactions_start_hook)
 	end
 end
 


### PR DESCRIPTION
Don't merge this commit until VMF switched to the new hook system.
This is the only mod that breaks with the new system, so I felt the need to be the one to submit required changes, found in the first commit.

The second commit improve the mod to not create new functions so often, and instead hooks the BuffExtetnsion and AmmoExtension once and disable it, then when the time comes inside the DamageUtils and DeathReaction hooks, it enables those hooks just for the execution of that function, keeping the same.