### PR TITLE
[Loadout Manager] Fixing broken loadout selection for hero selection view

### DIFF
--- a/loadout_manager/scripts/mods/loadout_manager/loadout_manager.lua
+++ b/loadout_manager/scripts/mods/loadout_manager/loadout_manager.lua
@@ -452,7 +452,7 @@ mod.create_window = function(self)
 					local frame_y = frame_scenegraph.world_position[2]
 					local button_size = {frame_width/3, frame_height/6}
 					for j = 1, 9 do
-						if self:loadout_exists(hero_name, i) then
+						if self:loadout_exists(hero_name, j) then
 
 							-- ##### Get position #####################################################################
 							local position = {}


### PR DESCRIPTION
For now, displaying saved loadout is not working properly when you're about to join someone's game, because instead of grabbing actual inventory indices it grabs value from another iterator.