### PR TITLE
[Simple UI] Fix close button positioning

### DIFF
--- a/simple_ui/scripts/mods/simple_ui/simple_ui.lua
+++ b/simple_ui/scripts/mods/simple_ui/simple_ui.lua
@@ -849,7 +849,7 @@ mod.widgets = {
 			Create close button
 		--]]
 		create_close_button = function(self, name, params)
-			local widget = self:create_widget(name, {5, 0}, {25, 25}, "close_button", mod.anchor.styles.top_right, params)
+			local widget = self:create_widget(name, {5, 0}, {25, 25}, "close_button", "top_right", params)
 			widget:set("text", "X")
 			self:add_widget(widget)
 			return widget


### PR DESCRIPTION
`mod.anchor.styles.top_right == nil` because `mod.anchor.styles` is a list, so this call incorrectly defaults to "bottom_left" in `create_widget`